### PR TITLE
Creates a new brain damage symptom

### DIFF
--- a/code/datums/diseases/advance/symptoms/migraine
+++ b/code/datums/diseases/advance/symptoms/migraine
@@ -1,0 +1,36 @@
+/*
+//////////////////////////////////////
+
+Brain degradation
+
+	Gives brain damage over time and replaces the stat loss from the removal of the Aggressive Viral Metabolism
+
+//////////////////////////////////////
+*/
+
+/datum/symptom/migraine
+
+	name = "Brain degradation"
+	desc = "The virus slowly synthesizes Impedrezene, effectively removes the need of thought in one's actions."
+	stealth = -2
+	resistance = 1
+	stage_speed = 3
+	transmittable = 1
+	severity = 3
+	level = 6
+	base_message_chance = 5
+	symptom_delay_min = 15
+	symptom_delay_max = 30
+
+/datum/symptom/migraine/Activate(datum/disease/advance/A)
+	if(!..())
+		return
+	var/mob/living/carbon/M = A.affected_mob
+	switch(A.stage)
+		if(4, 5)
+			M.adjustBrainLoss(5)
+			M.updatehealth()
+		else
+			if(prob(base_message_chance))
+				to_chat(M, "<span class='warning'>[pick("Your head aches.", "You hear a rattling sound in your head.", "You forgot what you were just thinking about.")]</span>")
+	return


### PR DESCRIPTION
Adds a new brain damage symptom that has the same stats as the recently removed Viral Aggressive Metabolism. As this is my first PR please judge freely.

:cl: davethwave
add: Added a new symptom that does brain damage
/:cl:

I made this to replace the stats missing from the Viral Aggressive Metabolism as well as add something that I though was fun to the game.
